### PR TITLE
Remove useless fields from Book Read model

### DIFF
--- a/backend/app/controllers/book_clubs_controller.rb
+++ b/backend/app/controllers/book_clubs_controller.rb
@@ -8,7 +8,7 @@ class BookClubsController < ApplicationController
   end
 
   def show
-    @current_read = @club.book_reads.where("meetup_time >= ?", Time.current).order(meetup_time: :desc).first
+    @current_read = @club.book_reads.where("meetup_time >= ?", Time.current).order(meetup_time: :asc).first
   end
 
   def new

--- a/backend/app/controllers/book_clubs_controller.rb
+++ b/backend/app/controllers/book_clubs_controller.rb
@@ -8,7 +8,7 @@ class BookClubsController < ApplicationController
   end
 
   def show
-    @current_read = @club.book_reads.active.order(start_date: :asc).first || @club.book_reads.upcoming.order(start_date: :asc).first
+    @current_read = @club.book_reads.where("meetup_time >= ?", Time.current).order(meetup_time: :desc).first
   end
 
   def new

--- a/backend/app/controllers/book_reads_controller.rb
+++ b/backend/app/controllers/book_reads_controller.rb
@@ -7,9 +7,9 @@ class BookReadsController < ApplicationController
   def index
     @tab = params[:tab] || "upcoming"
     if @tab == "past"
-      @reads = @book_club.book_reads.includes(:book).completed.order(end_date: :desc)
+      @reads = @book_club.book_reads.includes(:book).where("meetup_time < ?", Time.current).order(meetup_time: :desc)
     else
-      @reads = @book_club.book_reads.includes(:book).where(status: [ :active, :upcoming ]).order(start_date: :asc)
+      @reads = @book_club.book_reads.includes(:book).where("meetup_time >= ?", Time.current).order(meetup_time: :desc)
     end
   end
 

--- a/backend/app/dashboards/book_read_dashboard.rb
+++ b/backend/app/dashboards/book_read_dashboard.rb
@@ -12,13 +12,8 @@ class BookReadDashboard < Administrate::BaseDashboard
     book: Field::BelongsTo,
     book_club: Field::BelongsTo,
     discussion_questions: Field::HasMany,
-    end_date: Field::Date,
     meetup_location: Field::String,
-    meetup_location_lat: Field::String.with_options(searchable: false),
-    meetup_location_lon: Field::String.with_options(searchable: false),
     meetup_time: Field::DateTime,
-    start_date: Field::Date,
-    status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -42,13 +37,8 @@ class BookReadDashboard < Administrate::BaseDashboard
     book
     book_club
     discussion_questions
-    end_date
     meetup_location
-    meetup_location_lat
-    meetup_location_lon
     meetup_time
-    start_date
-    status
     created_at
     updated_at
   ].freeze
@@ -60,13 +50,8 @@ class BookReadDashboard < Administrate::BaseDashboard
     book
     book_club
     discussion_questions
-    end_date
     meetup_location
-    meetup_location_lat
-    meetup_location_lon
     meetup_time
-    start_date
-    status
   ].freeze
 
   # COLLECTION_FILTERS

--- a/backend/app/models/book_read.rb
+++ b/backend/app/models/book_read.rb
@@ -12,8 +12,6 @@ class BookRead < ApplicationRecord
 
   validate :has_book_or_poll
 
-  enum :status, { upcoming: 0, active: 1, completed: 2 }, default: :upcoming
-
   private
 
   def has_book_or_poll

--- a/backend/app/views/book_reads/_card.html.erb
+++ b/backend/app/views/book_reads/_card.html.erb
@@ -22,12 +22,6 @@
       <h3 class="text-lg font-bold text-gray-900 truncate group-hover:text-blue-600 transition-colors">
         <%= read.book&.title || read.poll&.text || "New Reading Session" %>
       </h3>
-      <span class="px-2.5 py-0.5 rounded-full text-xs font-semibold whitespace-nowrap
-        <%= read.status == 'completed' ? 'bg-green-100 text-green-800' :
-            read.status == 'active' ? 'bg-blue-100 text-blue-800' :
-            'bg-gray-100 text-gray-800' %>">
-        <%= read.status.titleize %>
-      </span>
     </div>
     
     <% if read.book.present? %>

--- a/backend/app/views/book_reads/show.html.erb
+++ b/backend/app/views/book_reads/show.html.erb
@@ -47,12 +47,6 @@
           <h1 class="text-3xl font-bold text-gray-900 leading-tight">
             <%= @book_read.book&.title || @book_read.poll&.text || "New Reading Session" %>
           </h1>
-          <span class="px-3 py-1 rounded-full text-sm font-semibold whitespace-nowrap ml-4
-            <%= @book_read.status == 'completed' ? 'bg-green-100 text-green-800' :
-                @book_read.status == 'active' ? 'bg-blue-100 text-blue-800' :
-                'bg-gray-100 text-gray-800' %>">
-            <%= @book_read.status.titleize %>
-          </span>
         </div>
         
         <% if @book_read.book.present? %>

--- a/backend/db/migrate/20260503143412_remove_old_fields_from_book_reads.rb
+++ b/backend/db/migrate/20260503143412_remove_old_fields_from_book_reads.rb
@@ -1,0 +1,9 @@
+class RemoveOldFieldsFromBookReads < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :book_reads, :start_date, :date
+    remove_column :book_reads, :end_date, :date
+    remove_column :book_reads, :status, :integer
+    remove_column :book_reads, :meetup_location_lat, :decimal, precision: 10, scale: 6
+    remove_column :book_reads, :meetup_location_lon, :decimal, precision: 10, scale: 6
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_01_001928) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_03_143412) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -64,14 +64,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_01_001928) do
   create_table "book_reads", force: :cascade do |t|
     t.integer "book_id"
     t.integer "book_club_id", null: false
-    t.date "start_date"
-    t.date "end_date"
-    t.integer "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "meetup_location"
-    t.decimal "meetup_location_lat", precision: 10, scale: 6
-    t.decimal "meetup_location_lon", precision: 10, scale: 6
     t.datetime "meetup_time"
     t.index ["book_club_id"], name: "index_book_reads_on_book_club_id"
     t.index ["book_id"], name: "index_book_reads_on_book_id"

--- a/backend/test/controllers/book_reads_controller_test.rb
+++ b/backend/test/controllers/book_reads_controller_test.rb
@@ -38,7 +38,7 @@ class BookReadsControllerTest < ActionDispatch::IntegrationTest
       post book_club_book_reads_url(@book_club.id), params: {
         book_read: {
           book_id: @book.id,
-          # Missing start_date which is required, and end_date before start_date
+          # Missing meetup_time which is required
           meetup_location: "Vino Vino Cafe"
         }
       }
@@ -63,9 +63,8 @@ class BookReadsControllerTest < ActionDispatch::IntegrationTest
         book_read: {
           book_id: @book.id,
           book_club_id: @book_club.id,
-          start_date: Date.today,
-          end_date: 1.month.from_now.to_date,
-          status: "upcoming"
+          meetup_time: Date.today,
+          meetup_location: "Vino Vino Cafe"
         }
       }
     end
@@ -93,30 +92,31 @@ class BookReadsControllerTest < ActionDispatch::IntegrationTest
   test "should update book_read for owner" do
     @book_read = book_reads(:one)
     sign_in @user
-    new_end_date = 2.months.from_now.to_date
+    new_time = 2.months.from_now.to_datetime
     patch book_club_book_read_url(@book_club, @book_read), params: {
       book_read: {
-        meetup_time: new_end_date
+        meetup_time: new_time
       }
     }
     assert_redirected_to book_club_book_read_url(@book_club, @book_read)
     assert_equal "Book read was successfully updated.", flash[:notice]
     @book_read.reload
-    assert_equal new_end_date, @book_read.meetup_time
+    # Compare with a small tolerance for database time precision
+    assert_in_delta new_time.to_i, @book_read.meetup_time.to_i, 1
   end
 
   test "should not update book_read if not owner" do
     @book_read = book_reads(:one)
     sign_in users(:two)
-    original_end_date = @book_read.meetup_time
+    original_time = @book_read.meetup_time
     patch book_club_book_read_url(@book_club, @book_read), params: {
       book_read: {
-        meetup_time: 2.months.from_now.to_date
+        meetup_time: 2.months.from_now.to_datetime
       }
     }
     assert_redirected_to book_club_url(@book_club)
     assert_equal "You are not authorized to perform this action.", flash[:alert]
     @book_read.reload
-    assert_equal original_end_date, @book_read.meetup_time
+    assert_equal original_time.to_i, @book_read.meetup_time.to_i
   end
 end

--- a/backend/test/fixtures/book_reads.yml
+++ b/backend/test/fixtures/book_reads.yml
@@ -5,11 +5,9 @@ one:
   book_club: one
   meetup_time: 2026-03-24
   meetup_location: Vino Vino Cafe
-  status: 1
 
 two:
   book: two
   book_club: two
   meetup_time: 2026-03-24
   meetup_location: Dreamers cafe
-  status: 1

--- a/backend/test/models/book_read_test.rb
+++ b/backend/test/models/book_read_test.rb
@@ -8,8 +8,7 @@ class BookReadTest < ActiveSupport::TestCase
       book: @book,
       book_club: @club,
       meetup_time: 1.week.from_now,
-      meetup_location: "Vino Vino Cafe",
-      status: :upcoming
+      meetup_location: "Vino Vino Cafe"
     )
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reading sessions are now determined and listed by meetup time (not by status/date ranges).
  * Past and upcoming tabs filter by meetup time.

* **UI**
  * Status badges removed from reading session cards and detail pages.

* **Admin**
  * Legacy date/status and separate lat/lon fields removed from admin forms/views; meetup time and location remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->