### PR TITLE
Add max-capacity field for book read

### DIFF
--- a/backend/app/controllers/book_reads_controller.rb
+++ b/backend/app/controllers/book_reads_controller.rb
@@ -65,6 +65,7 @@ class BookReadsController < ApplicationController
   def book_read_params
     params.require(:book_read).permit(
       :book_id,
+      :max_capacity,
       :meetup_time,
       :meetup_location,
       poll_attributes: [

--- a/backend/app/models/book_read.rb
+++ b/backend/app/models/book_read.rb
@@ -9,7 +9,7 @@ class BookRead < ApplicationRecord
 
   validates :meetup_time, presence: true
   validates :meetup_location, presence: true
-  validates :max_capacity, numericality: { greater_than_or_equal_to: 2 }, allow_nil: true
+  validates :max_capacity, numericality: { only_integer: true, greater_than_or_equal_to: 2 }, allow_nil: true
 
   validate :has_book_or_poll
 

--- a/backend/app/models/book_read.rb
+++ b/backend/app/models/book_read.rb
@@ -9,6 +9,7 @@ class BookRead < ApplicationRecord
 
   validates :meetup_time, presence: true
   validates :meetup_location, presence: true
+  validates :max_capacity, numericality: { greater_than_or_equal_to: 2 }, allow_nil: true
 
   validate :has_book_or_poll
 

--- a/backend/app/views/book_reads/_form.html.erb
+++ b/backend/app/views/book_reads/_form.html.erb
@@ -112,6 +112,14 @@
   <%# Shared Fields %>
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
     <div class="space-y-1">
+      <%= form.label :max_capacity, class: "block text-sm font-medium text-gray-500" %>
+      <%= form.number_field :max_capacity,
+          min: 2,
+          placeholder: "e.g., 12",
+          class: "block w-full rounded-md border-gray-300 bg-gray-50 py-2 px-3 text-sm text-gray-900 focus:bg-white focus:border-blue-500 transition-all outline-none" %>
+    </div>
+
+    <div class="space-y-1">
       <%= form.label :meetup_time, class: "block text-sm font-medium text-gray-500" %>
       <%= form.datetime_field :meetup_time, 
           class: "block w-full rounded-md border-gray-300 bg-gray-50 py-2 px-3 text-sm text-gray-900 focus:bg-white focus:border-blue-500 transition-all outline-none" %>

--- a/backend/app/views/book_reads/show.html.erb
+++ b/backend/app/views/book_reads/show.html.erb
@@ -55,7 +55,7 @@
 
         <div class="bg-blue-50/50 rounded-xl p-6 mb-8 border border-blue-100">
           <h3 class="text-xs font-semibold text-blue-800 uppercase tracking-wider mb-4">Meetup Details</h3>
-          <div class="grid grid-cols-2 gap-6">
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
             <div>
               <p class="text-sm text-gray-500 mb-1">When</p>
               <p class="font-semibold text-gray-900"><%= @book_read.meetup_time&.strftime("%B %d, %Y at %H:%M") || 'Not set' %></p>
@@ -63,6 +63,10 @@
             <div>
               <p class="text-sm text-gray-500 mb-1">Where</p>
               <p class="font-semibold text-gray-900"><%= @book_read.meetup_location.presence || 'Not set' %></p>
+            </div>
+            <div>
+              <p class="text-sm text-gray-500 mb-1">Max capacity</p>
+              <p class="font-semibold text-gray-900"><%= @book_read.max_capacity.presence || 'Not set' %></p>
             </div>
           </div>
         </div>

--- a/backend/db/migrate/20260512024713_add_max_capacity_to_book_reads.rb
+++ b/backend/db/migrate/20260512024713_add_max_capacity_to_book_reads.rb
@@ -1,0 +1,7 @@
+class AddMaxCapacityToBookReads < ActiveRecord::Migration[8.0]
+  def change
+    add_column :book_reads, :max_capacity, :integer, null: true
+
+    add_check_constraint :book_reads, "max_capacity IS NULL OR max_capacity >= 2", name: "book_reads_max_capacity_min"
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_03_143412) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_12_024713) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -68,8 +68,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_03_143412) do
     t.datetime "updated_at", null: false
     t.string "meetup_location"
     t.datetime "meetup_time"
+    t.integer "max_capacity"
     t.index ["book_club_id"], name: "index_book_reads_on_book_club_id"
     t.index ["book_id"], name: "index_book_reads_on_book_id"
+    t.check_constraint "max_capacity IS NULL OR max_capacity >= 2", name: "book_reads_max_capacity_min"
   end
 
   create_table "book_tags", force: :cascade do |t|

--- a/backend/test/models/book_read_test.rb
+++ b/backend/test/models/book_read_test.rb
@@ -48,4 +48,19 @@ class BookReadTest < ActiveSupport::TestCase
     @book_read.meetup_time = nil
     assert_not @book_read.valid?
   end
+
+  test "should allow nil max_capacity" do
+    @book_read.max_capacity = nil
+    assert @book_read.valid?
+  end
+
+  test "should allow max_capacity of 2" do
+    @book_read.max_capacity = 2
+    assert @book_read.valid?
+  end
+
+  test "should not allow max_capacity below 2" do
+    @book_read.max_capacity = 1
+    assert_not @book_read.valid?
+  end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "Max capacity" numeric field to meetup forms and meetup details (shows "Not set" when blank).

* **Validation**
  * Max capacity must be an integer ≥ 2 (or left blank).

* **Tests**
  * Added tests covering nil, valid (2), and invalid (<2) max capacity behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nebiyuelias1/arif-nibaboch/pull/51)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->