### PR TITLE
Allow rsvp to book read session

### DIFF
--- a/backend/app/models/book_read.rb
+++ b/backend/app/models/book_read.rb
@@ -4,6 +4,8 @@ class BookRead < ApplicationRecord
 
   has_one :poll, dependent: :destroy
   has_many :discussion_questions, dependent: :destroy
+  has_many :book_read_rsvps, dependent: :destroy
+  has_many :rsvp_users, through: :book_read_rsvps, source: :user
 
   accepts_nested_attributes_for :poll, reject_if: :all_blank
 

--- a/backend/app/models/book_read_rsvp.rb
+++ b/backend/app/models/book_read_rsvp.rb
@@ -1,0 +1,22 @@
+class BookReadRsvp < ApplicationRecord
+  enum :status, { going: 0, waitlisted: 1, cancelled: 2 }
+
+  belongs_to :book_read
+  belongs_to :user
+
+  validates :status, presence: true
+  validates :user_id, uniqueness: { scope: :book_read_id }
+
+  validate :capacity_available_for_going, if: :going?
+
+  private
+
+  def capacity_available_for_going
+    return if book_read.max_capacity.blank?
+
+    going_count = book_read.book_read_rsvps.going.count
+    return if going_count < book_read.max_capacity
+
+    errors.add(:base, "This session is full")
+  end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
   has_many :reviews, dependent: :destroy
   has_many :review_likes, dependent: :destroy
   has_many :owned_book_clubs, class_name: "BookClub", foreign_key: "owner_id", dependent: :nullify
+  has_many :book_read_rsvps, dependent: :destroy
+  has_many :rsvp_book_reads, through: :book_read_rsvps, source: :book_read
 
   def self.from_telegram_auth(auth)
     user = where(telegram_id: auth["id"]).first_or_initialize do |u|

--- a/backend/db/migrate/20260512110000_create_book_read_rsvps.rb
+++ b/backend/db/migrate/20260512110000_create_book_read_rsvps.rb
@@ -1,0 +1,13 @@
+class CreateBookReadRsvps < ActiveRecord::Migration[7.1]
+  def change
+    create_table :book_read_rsvps do |t|
+      t.references :book_read, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.integer :status, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :book_read_rsvps, [ :book_read_id, :user_id ], unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_12_024713) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_12_110000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -59,6 +59,17 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_12_024713) do
     t.datetime "updated_at", null: false
     t.integer "book_club_members_count", default: 0, null: false
     t.index ["owner_id"], name: "index_book_clubs_on_owner_id"
+  end
+
+  create_table "book_read_rsvps", force: :cascade do |t|
+    t.integer "book_read_id", null: false
+    t.integer "user_id", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["book_read_id", "user_id"], name: "index_book_read_rsvps_on_book_read_id_and_user_id", unique: true
+    t.index ["book_read_id"], name: "index_book_read_rsvps_on_book_read_id"
+    t.index ["user_id"], name: "index_book_read_rsvps_on_user_id"
   end
 
   create_table "book_reads", force: :cascade do |t|
@@ -219,6 +230,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_12_024713) do
   add_foreign_key "book_club_members", "book_clubs"
   add_foreign_key "book_club_members", "users"
   add_foreign_key "book_clubs", "users", column: "owner_id"
+  add_foreign_key "book_read_rsvps", "book_reads"
+  add_foreign_key "book_read_rsvps", "users"
   add_foreign_key "book_reads", "book_clubs"
   add_foreign_key "book_reads", "books"
   add_foreign_key "book_tags", "books"

--- a/backend/test/fixtures/users.yml
+++ b/backend/test/fixtures/users.yml
@@ -13,3 +13,10 @@ two:
   name: "Test User Two"
   username: "testuser2"
   admin: false
+
+three:
+  email: user3@example.com
+  encrypted_password: "<%= BCrypt::Password.create('password123', cost: 4) %>"
+  name: "Test User Three"
+  username: "testuser3"
+  admin: false

--- a/backend/test/models/book_read_rsvp_test.rb
+++ b/backend/test/models/book_read_rsvp_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class BookReadRsvpTest < ActiveSupport::TestCase
+  def setup
+    @book_read = book_reads(:one)
+    @user = users(:one)
+  end
+
+  test "is valid with a book read and user" do
+    rsvp = BookReadRsvp.new(book_read: @book_read, user: @user, status: :going)
+    assert rsvp.valid?
+  end
+
+  test "requires a unique user per book read" do
+    BookReadRsvp.create!(book_read: @book_read, user: @user, status: :going)
+    duplicate = BookReadRsvp.new(book_read: @book_read, user: @user, status: :going)
+
+    assert_not duplicate.valid?
+  end
+
+  test "allows going when capacity is available" do
+    @book_read.update!(max_capacity: 2)
+    BookReadRsvp.create!(book_read: @book_read, user: users(:two), status: :going)
+
+    rsvp = BookReadRsvp.new(book_read: @book_read, user: @user, status: :going)
+    assert rsvp.valid?
+  end
+
+  test "prevents going when capacity is full" do
+    @book_read.update!(max_capacity: 2)
+    BookReadRsvp.create!(book_read: @book_read, user: users(:one), status: :going)
+    BookReadRsvp.create!(book_read: @book_read, user: users(:two), status: :going)
+
+    rsvp = BookReadRsvp.new(book_read: @book_read, user: @user, status: :going)
+    assert_not rsvp.valid?
+    assert_includes rsvp.errors.full_messages, "This session is full"
+  end
+
+  test "allows waitlisted when capacity is full" do
+    @book_read.update!(max_capacity: 2)
+    BookReadRsvp.create!(book_read: @book_read, user: users(:one), status: :going)
+    BookReadRsvp.create!(book_read: @book_read, user: users(:two), status: :going)
+
+    rsvp = BookReadRsvp.new(book_read: @book_read, user: users(:three), status: :waitlisted)
+    assert rsvp.valid?
+  end
+end

--- a/backend/test/models/book_read_rsvp_test.rb
+++ b/backend/test/models/book_read_rsvp_test.rb
@@ -31,7 +31,7 @@ class BookReadRsvpTest < ActiveSupport::TestCase
     BookReadRsvp.create!(book_read: @book_read, user: users(:one), status: :going)
     BookReadRsvp.create!(book_read: @book_read, user: users(:two), status: :going)
 
-    rsvp = BookReadRsvp.new(book_read: @book_read, user: @user, status: :going)
+    rsvp = BookReadRsvp.new(book_read: @book_read, user: users(:three), status: :going)
     assert_not rsvp.valid?
     assert_includes rsvp.errors.full_messages, "This session is full"
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RSVP system for book-read events with statuses: going, waitlisted, cancelled
  * Enforced single RSVP per user per event and capacity-aware blocking of additional "going" sign-ups when sessions are full
* **Tests**
  * Added model tests covering RSVP creation, uniqueness, capacity limits, and waitlisting behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nebiyuelias1/arif-nibaboch/pull/52)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->