### PR TITLE
Add delete question action

### DIFF
--- a/backend/app/controllers/discussion_questions_controller.rb
+++ b/backend/app/controllers/discussion_questions_controller.rb
@@ -2,7 +2,9 @@ class DiscussionQuestionsController < ApplicationController
   prepend_before_action :store_discussion_question_draft, only: [ :create ]
   before_action :authenticate_user!
   before_action :set_book_club_and_read
-  before_action -> { authorize_discussion_question_permission }, only: [ :create, :update ]
+  before_action :set_discussion_question, only: [ :update, :destroy ]
+  before_action :authorize_discussion_question_permission, only: [ :create ]
+  before_action :authorize_discussion_question_modification, only: [ :update, :destroy ]
 
   def create
     @discussion_question = @book_read.discussion_questions.build(discussion_question_params.merge(user: current_user))
@@ -21,8 +23,6 @@ class DiscussionQuestionsController < ApplicationController
   end
 
   def update
-    @discussion_question = @book_read.discussion_questions.find(params[:id])
-
     if @discussion_question.update(discussion_question_update_params)
       respond_to do |format|
         format.turbo_stream { render turbo_stream: turbo_stream.replace(@discussion_question, partial: "discussion_questions/discussion_question", locals: { discussion_question: @discussion_question }) }
@@ -36,7 +36,20 @@ class DiscussionQuestionsController < ApplicationController
     end
   end
 
+  def destroy
+    @discussion_question.destroy
+
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.remove(@discussion_question) }
+      format.html { redirect_to book_club_book_read_path(@book_club, @book_read), notice: "Question deleted successfully." }
+    end
+  end
+
   private
+
+  def set_discussion_question
+    @discussion_question = @book_read.discussion_questions.find(params[:id])
+  end
 
   def set_book_club_and_read
     @book_club = BookClub.find(params[:book_club_id])
@@ -62,6 +75,14 @@ class DiscussionQuestionsController < ApplicationController
     has_rsvp = @book_read.rsvp_users.exists?(id: current_user.id)
     return if has_rsvp
 
+    authorize_club_owner!(@book_club, redirect_url: book_club_book_read_path(@book_club, @book_read))
+  end
+
+  def authorize_discussion_question_modification
+    # Allow if user is the author
+    return if @discussion_question.user == current_user
+
+    # Allow if user is club owner or admin
     authorize_club_owner!(@book_club, redirect_url: book_club_book_read_path(@book_club, @book_read))
   end
 end

--- a/backend/app/controllers/discussion_questions_controller.rb
+++ b/backend/app/controllers/discussion_questions_controller.rb
@@ -23,7 +23,13 @@ class DiscussionQuestionsController < ApplicationController
   end
 
   def update
-    if @discussion_question.update(discussion_question_update_params)
+    update_params = if @book_club.owner == current_user || @book_club.book_club_members.exists?(user: current_user, role: :admin)
+                      discussion_question_update_params
+    else
+                      discussion_question_params
+    end
+
+    if @discussion_question.update(update_params)
       respond_to do |format|
         format.turbo_stream { render turbo_stream: turbo_stream.replace(@discussion_question, partial: "discussion_questions/discussion_question", locals: { discussion_question: @discussion_question }) }
         format.html { redirect_to book_club_book_read_path(@book_club, @book_read), notice: "Question updated successfully." }
@@ -38,9 +44,10 @@ class DiscussionQuestionsController < ApplicationController
 
   def destroy
     @discussion_question.destroy
+    @visible_questions = @book_read.visible_discussion_questions_for(current_user)
 
     respond_to do |format|
-      format.turbo_stream { render turbo_stream: turbo_stream.remove(@discussion_question) }
+      format.turbo_stream
       format.html { redirect_to book_club_book_read_path(@book_club, @book_read), notice: "Question deleted successfully." }
     end
   end

--- a/backend/app/javascript/controllers/auth_visibility_controller.js
+++ b/backend/app/javascript/controllers/auth_visibility_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["menu"];
+  static values = {
+    authorId: String,
+    clubOwnerId: String,
+  };
+
+  connect() {
+    const currentUserId = document.querySelector(
+      'meta[name="current-user-id"]',
+    )?.content;
+
+    if (!currentUserId) return;
+
+    const isAuthor = currentUserId === this.authorIdValue;
+    const isClubOwner = currentUserId === this.clubOwnerIdValue;
+    const isClubAdmin = this.clubAdminIdsValue.includes(
+      parseInt(currentUserId),
+    );
+
+    if (isAuthor || isClubOwner || isClubAdmin) {
+      this.menuTarget.classList.remove("hidden");
+    }
+  }
+}

--- a/backend/app/javascript/controllers/auth_visibility_controller.js
+++ b/backend/app/javascript/controllers/auth_visibility_controller.js
@@ -16,9 +16,6 @@ export default class extends Controller {
 
     const isAuthor = currentUserId === this.authorIdValue;
     const isClubOwner = currentUserId === this.clubOwnerIdValue;
-    const isClubAdmin = this.clubAdminIdsValue.includes(
-      parseInt(currentUserId),
-    );
 
     if (isAuthor || isClubOwner || isClubAdmin) {
       this.menuTarget.classList.remove("hidden");

--- a/backend/app/models/book_read.rb
+++ b/backend/app/models/book_read.rb
@@ -23,6 +23,17 @@ class BookRead < ApplicationRecord
     rsvp_users.exists?(id: user.id)
   end
 
+  def visible_discussion_questions_for(user)
+    questions = discussion_questions.includes(:question_translations)
+    if user&.admin? || book_club.owner == user || book_club.book_club_members.exists?(user: user, role: :admin)
+      questions.order(:position)
+    else
+      visible = questions.revealed
+      visible = visible.or(questions.where(user: user)) if user
+      visible.order(:position)
+    end
+  end
+
   private
 
   def has_book_or_poll

--- a/backend/app/views/book_reads/show.html.erb
+++ b/backend/app/views/book_reads/show.html.erb
@@ -358,29 +358,10 @@
         <% end %>
       </div>
 
-      <div
-        id="no_discussion_questions"
-        class="
-          text-center py-10 bg-background rounded-lg border border-dashed border-border
-          mt-4 <%= 'hidden' if @discussion_questions.any? %>
-        "
-      >
-        <svg
-          class="mx-auto h-12 w-12 text-content-muted"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="1.5"
-            d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
-          />
-        </svg>
-        <h3 class="mt-2 text-sm font-medium text-content">No discussion so far</h3>
-        <p class="mt-1 text-sm text-content-subtle">Check back later for questions to discuss!</p>
+      <div id="no_discussion_questions_wrapper">
+        <% if @discussion_questions.where.not(id: nil).empty? %>
+          <%= render partial: "discussion_questions/no_questions" %>
+        <% end %>
       </div>
     </div>
 </div>

--- a/backend/app/views/discussion_questions/_discussion_question.html.erb
+++ b/backend/app/views/discussion_questions/_discussion_question.html.erb
@@ -1,4 +1,8 @@
-<div id="<%= dom_id(discussion_question) %>" class="p-5 sm:p-6 bg-surface rounded-2xl border border-border shadow-sm hover:shadow-md transition-shadow">
+<div id="<%= dom_id(discussion_question) %>" 
+     class="p-5 sm:p-6 bg-surface rounded-2xl border border-border shadow-sm hover:shadow-md transition-shadow"
+     data-controller="auth-visibility"
+     data-auth-visibility-author-id-value="<%= discussion_question.user_id %>"
+     data-auth-visibility-club-owner-id-value="<%= discussion_question.book_read.book_club.owner_id %>">
   <div class="flex items-center justify-between gap-4">
     <div class="flex items-center gap-3 min-w-0">
       <% if discussion_question.user.present? %>
@@ -17,9 +21,44 @@
         </div>
       <% end %>
     </div>
-    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-background text-content border border-border flex-shrink-0">
-      #<%= discussion_question.position %>
-    </span>
+    
+    <div class="flex items-center gap-2">
+      <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-background text-content border border-border flex-shrink-0">
+        #<%= discussion_question.position %>
+      </span>
+
+      <div class="hidden relative text-left" 
+           data-controller="dropdown"
+           data-auth-visibility-target="menu">
+        <button type="button" 
+                class="flex items-center justify-center w-8 h-8 rounded-full hover:bg-background transition-colors text-content-subtle hover:text-content focus:outline-none" 
+                data-action="click->dropdown#toggle"
+                aria-expanded="false" 
+                aria-haspopup="true">
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+            <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+          </svg>
+        </button>
+
+        <div class="hidden absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-surface border border-border ring-1 ring-black ring-opacity-5 focus:outline-none z-50" 
+             data-dropdown-target="menu"
+             role="menu" 
+             aria-orientation="vertical">
+          <div class="py-1" role="none">
+            <%= button_to book_club_book_read_discussion_question_path(discussion_question.book_read.book_club, discussion_question.book_read, discussion_question), 
+                method: :delete, 
+                class: "w-full text-left flex items-center gap-2 px-4 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors", 
+                data: { turbo_confirm: "Are you sure you want to delete this question?" },
+                role: "menuitem" do %>
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+              Delete
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 
   <div class="mt-4 space-y-3">
@@ -51,6 +90,7 @@
           Draft
         </span>
         
+        <%# Visibility of these actions is still server-side for now as they are primary owner actions %>
         <% if user_signed_in? && current_user == discussion_question.book_read.book_club.owner %>
           <%= button_to book_club_book_read_discussion_question_path(discussion_question.book_read.book_club, discussion_question.book_read, discussion_question), method: :patch, params: { discussion_question: { status: :approved } }, class: "inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-background text-primary border border-primary hover:bg-background transition-colors cursor-pointer" do %>
             Approve

--- a/backend/app/views/discussion_questions/_no_questions.html.erb
+++ b/backend/app/views/discussion_questions/_no_questions.html.erb
@@ -1,0 +1,21 @@
+<div
+  id="no_discussion_questions"
+  class="text-center py-10 bg-background rounded-lg border border-dashed border-border mt-4"
+>
+  <svg
+    class="mx-auto h-12 w-12 text-content-muted"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.5"
+      d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+    />
+  </svg>
+  <h3 class="mt-2 text-sm font-medium text-content">No discussion so far</h3>
+  <p class="mt-1 text-sm text-content-subtle">Check back later for questions to discuss!</p>
+</div>

--- a/backend/app/views/discussion_questions/create.turbo_stream.erb
+++ b/backend/app/views/discussion_questions/create.turbo_stream.erb
@@ -2,7 +2,7 @@
   <%= render partial: "discussion_questions/discussion_question", locals: { discussion_question: @discussion_question } %>
 <% end %>
 
-<%= turbo_stream.remove "no_discussion_questions" %>
+<%= turbo_stream.update "no_discussion_questions_wrapper", "" %>
 
 <%= turbo_stream.replace "new_discussion_question_form" do %>
   <%= render partial: "discussion_questions/form", locals: { book_club: @book_club, book_read: @book_read, discussion_question: DiscussionQuestion.new } %>

--- a/backend/app/views/discussion_questions/destroy.turbo_stream.erb
+++ b/backend/app/views/discussion_questions/destroy.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.remove @discussion_question %>
+
+<% if @visible_questions.empty? %>
+  <%= turbo_stream.update "no_discussion_questions_wrapper" do %>
+    <%= render partial: "discussion_questions/no_questions" %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.append "toast_triggers" do %>
+  <div data-controller="flash-toast" data-flash-toast-message-value="Question deleted successfully." data-flash-toast-type-value="success"></div>
+<% end %>

--- a/backend/app/views/layouts/application.html.erb
+++ b/backend/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%= tag.meta name: "current-user-id", content: current_user&.id %>
+
     <%= yield :head %>
 
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -142,7 +142,7 @@ Devise.setup do |config|
   # without confirming their account.
   # Default is 0.days, meaning the user cannot access the website without
   # confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = Rails.env.production? ? 0.days : nil
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -56,8 +56,9 @@ Rails.application.routes.draw do
     resources :members, controller: "book_club_members", only: [ :update, :destroy ]
     resources :book_reads do
       resource :rsvp, controller: "book_read_rsvps", only: [ :create, :update ]
-      resources :discussion_questions, only: [ :create, :update ]
+      resources :discussion_questions, only: [ :create, :update, :destroy ]
       resources :poll_votes, only: [ :create ]
+
       member do
         get :finalize
         patch :select_book

--- a/backend/test/controllers/discussion_questions_controller_test.rb
+++ b/backend/test/controllers/discussion_questions_controller_test.rb
@@ -107,4 +107,53 @@ class DiscussionQuestionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes @response.body, content
   end
+
+  test "should delete a discussion question" do
+    question = discussion_questions(:one)
+    assert_difference("DiscussionQuestion.count", -1) do
+      delete book_club_book_read_discussion_question_path(@book_club, @book_read, question)
+    end
+
+    assert_redirected_to book_club_book_read_path(@book_club, @book_read)
+    assert_equal "Question deleted successfully.", flash[:notice]
+  end
+
+  test "should delete a discussion question via turbo stream" do
+    question = discussion_questions(:one)
+    assert_difference("DiscussionQuestion.count", -1) do
+      delete book_club_book_read_discussion_question_path(@book_club, @book_read, question), as: :turbo_stream
+    end
+
+    assert_response :success
+    assert_match /turbo-stream action="remove" target="discussion_question_#{question.id}"/, @response.body
+  end
+
+  test "should not delete discussion question if not author or admin" do
+    sign_out @user
+    other_user = users(:two) # not author of question :one
+    sign_in other_user
+
+    question = discussion_questions(:one)
+    assert_no_difference("DiscussionQuestion.count") do
+      delete book_club_book_read_discussion_question_path(@book_club, @book_read, question)
+    end
+
+    assert_redirected_to book_club_book_read_path(@book_club, @book_read)
+    assert_equal "You are not authorized to perform this action.", flash[:alert]
+  end
+
+  test "author can delete their own discussion question" do
+    # Sign in as user two, who authored question two
+    sign_out @user
+    author = users(:two)
+    sign_in author
+    question = discussion_questions(:two)
+
+    assert_difference("DiscussionQuestion.count", -1) do
+      delete book_club_book_read_discussion_question_path(book_clubs(:two), book_reads(:two), question)
+    end
+
+    assert_redirected_to book_club_book_read_path(book_clubs(:two), book_reads(:two))
+    assert_equal "Question deleted successfully.", flash[:notice]
+  end
 end

--- a/backend/test/controllers/discussion_questions_controller_test.rb
+++ b/backend/test/controllers/discussion_questions_controller_test.rb
@@ -35,7 +35,7 @@ class DiscussionQuestionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal "text/vnd.turbo-stream.html", @response.media_type
     assert_match /turbo-stream action="append" target="discussion_questions_list"/, @response.body
-    assert_match /turbo-stream action="remove" target="no_discussion_questions"/, @response.body
+    assert_match /turbo-stream action="update" target="no_discussion_questions_wrapper"/, @response.body
     assert DiscussionQuestion.last.draft?
   end
 
@@ -118,14 +118,19 @@ class DiscussionQuestionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Question deleted successfully.", flash[:notice]
   end
 
-  test "should delete a discussion question via turbo stream" do
-    question = discussion_questions(:one)
+  test "should delete a discussion question via turbo stream and restore placeholder if last one" do
+    # Ensure there is only one question for this book read that is visible
+    @book_read.discussion_questions.destroy_all
+    question = @book_read.discussion_questions.create!(user: @user, content: "Only question")
+
     assert_difference("DiscussionQuestion.count", -1) do
       delete book_club_book_read_discussion_question_path(@book_club, @book_read, question), as: :turbo_stream
     end
 
     assert_response :success
     assert_match /turbo-stream action="remove" target="discussion_question_#{question.id}"/, @response.body
+    assert_match /turbo-stream action="update" target="no_discussion_questions_wrapper"/, @response.body
+    assert_match /No discussion so far/, @response.body
   end
 
   test "should not delete discussion question if not author or admin" do
@@ -155,5 +160,45 @@ class DiscussionQuestionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to book_club_book_read_path(book_clubs(:two), book_reads(:two))
     assert_equal "Question deleted successfully.", flash[:notice]
+  end
+
+  test "author cannot update status of their own discussion question if not owner or admin" do
+    sign_out @user
+    author = users(:two) # Not admin, not owner of club one
+    sign_in author
+
+    # Manually create a question for user two in book_read one (owned by user one)
+    question = @book_read.discussion_questions.create!(user: author, content: "Author's question")
+
+    assert_equal "draft", question.status
+
+    patch book_club_book_read_discussion_question_path(@book_club, @book_read, question), params: {
+      discussion_question: {
+        content: "Updated content",
+        status: "approved"
+      }
+    }
+
+    assert_redirected_to book_club_book_read_path(@book_club, @book_read)
+    question.reload
+    assert_equal "Updated content", question.content
+    assert_equal "draft", question.status # Status should NOT change
+  end
+
+  test "club owner can update status of any discussion question" do
+    # @user is the owner of @book_club
+    author = users(:two)
+    question = @book_read.discussion_questions.create!(user: author, content: "Author's question")
+
+    assert_equal "draft", question.status
+
+    patch book_club_book_read_discussion_question_path(@book_club, @book_read, question), params: {
+      discussion_question: {
+        status: "approved"
+      }
+    }
+
+    assert_redirected_to book_club_book_read_path(@book_club, @book_read)
+    assert_equal "approved", question.reload.status
   end
 end

--- a/backend/test/fixtures/discussion_questions.yml
+++ b/backend/test/fixtures/discussion_questions.yml
@@ -2,12 +2,14 @@
 
 one:
   book_read: one
+  user: one
   status: 1
   content: MyText
   position: 1
 
 two:
   book_read: two
+  user: two
   status: 1
   content: MyText
   position: 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can delete discussion questions; only the question author or club owner can perform deletions. Deletions support Turbo Stream removal and standard redirects with success messages.
  * Action menu for discussion questions now appears client-side for authorized users (author/club owner/admin).

* **Tests**
  * Added end-to-end coverage for deletion flows, authorization, redirects, notifications, and Turbo Stream removal.

* **Chores**
  * Sign-in confirmation behavior adjusted by environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->