### PR TITLE
Allow adding club photo

### DIFF
--- a/backend/app/controllers/admin/book_clubs_controller.rb
+++ b/backend/app/controllers/admin/book_clubs_controller.rb
@@ -29,18 +29,17 @@ module Admin
     #   end
     # end
 
-    # Override `resource_params` if you want to transform the submitted
-    # data before it's persisted. For example, the following would turn all
-    # empty values into nil values. It uses other APIs such as `resource_class`
-    # and `dashboard`:
-    #
-    # def resource_params
-    #   params.require(resource_class.model_name.param_key).
-    #     permit(dashboard.permitted_attributes(action_name)).
-    #     transform_values { |value| value == "" ? nil : value }
-    # end
+    private
 
-    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
-    # for more information
+    def resource_params
+      params.require(:book_club).permit(
+        :name,
+        :description,
+        :is_private,
+        :owner_id,
+        :photo,
+        :cover_photo
+      )
+    end
   end
 end

--- a/backend/app/controllers/book_clubs_controller.rb
+++ b/backend/app/controllers/book_clubs_controller.rb
@@ -69,7 +69,7 @@ class BookClubsController < ApplicationController
   end
 
   def club_params
-    params.require(:book_club).permit(:name, :description, :is_private, :cover_photo)
+    params.require(:book_club).permit(:name, :description, :is_private, :cover_photo, :photo)
   end
 
   def set_book_club

--- a/backend/app/dashboards/book_club_dashboard.rb
+++ b/backend/app/dashboards/book_club_dashboard.rb
@@ -13,8 +13,6 @@ class BookClubDashboard < Administrate::BaseDashboard
     book_club_members_count: Field::Number,
     book_reads: Field::HasMany,
     books: Field::HasMany,
-    cover_photo_attachment: Field::HasOne,
-    cover_photo_blob: Field::HasOne,
     description: Field::Text,
     is_private: Field::Boolean,
     members: Field::HasMany,
@@ -31,26 +29,21 @@ class BookClubDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     id
-    book_club_members
+    name
+    owner
     book_club_members_count
-    book_reads
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
-    book_club_members
-    book_club_members_count
-    book_reads
-    books
-    cover_photo_attachment
-    cover_photo_blob
+    name
     description
     is_private
-    members
-    name
     owner
+    book_club_members
+    book_reads
     created_at
     updated_at
   ].freeze

--- a/backend/app/models/book_club.rb
+++ b/backend/app/models/book_club.rb
@@ -13,7 +13,11 @@ class BookClub < ApplicationRecord
   has_many :book_club_members, dependent: :destroy
   has_many :members, through: :book_club_members, source: :user
 
+  MAX_PHOTO_SIZE = 5.megabytes
+  ALLOWED_PHOTO_TYPES = %w[image/jpeg image/jpg image/png image/webp image/gif].freeze
+
   validates :name, presence: true
+  validate :acceptable_photo
 
   after_create :add_owner_as_admin
 
@@ -24,6 +28,24 @@ class BookClub < ApplicationRecord
   end
 
   private
+
+  def acceptable_photo
+    return unless photo.attached?
+
+    if photo.content_type == "image/svg+xml" || photo.filename.to_s.downcase.end_with?(".svg")
+      errors.add(:photo, "cannot be an SVG file for security reasons")
+      return
+    end
+
+    unless ALLOWED_PHOTO_TYPES.include?(photo.content_type)
+      errors.add(:photo, "must be a JPEG, PNG, WEBP, or GIF image")
+      return
+    end
+
+    if photo.blob.byte_size > MAX_PHOTO_SIZE
+      errors.add(:photo, "is too large (maximum size is 5MB)")
+    end
+  end
 
   def add_owner_as_admin
     if owner.present?

--- a/backend/app/models/book_club.rb
+++ b/backend/app/models/book_club.rb
@@ -2,6 +2,11 @@ class BookClub < ApplicationRecord
   belongs_to :owner, class_name: "User", optional: true
 
   has_one_attached :cover_photo
+  has_one_attached :photo
+
+  def name_initial
+    name.presence&.strip&.first&.upcase || "B"
+  end
 
   has_many :book_reads, dependent: :destroy
   has_many :books, through: :book_reads

--- a/backend/app/views/admin/book_clubs/_form.html.erb
+++ b/backend/app/views/admin/book_clubs/_form.html.erb
@@ -1,0 +1,59 @@
+<%= form_for([namespace, page.resource], html: { class: "form", multipart: true }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.actions.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.controller.error")),
+          resource_name: page.resource_name,
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes(action_name).each do |title, attributes| -%>
+    <% attributes.each do |attribute| -%>
+      <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= attribute.attribute %>">
+        <%= render_field attribute, f: f %>
+      </div>
+    <% end -%>
+  <% end -%>
+
+  <div class="field-unit field-unit--file">
+    <div class="field-unit__label">
+      <%= f.label :photo, "Club Avatar Photo" %>
+    </div>
+    <div class="field-unit__field">
+      <% if page.resource.persisted? && page.resource.photo.attached? %>
+        <div style="margin-bottom: 8px;">
+          <%= image_tag page.resource.photo, alt: "", style: "width: 48px; height: 48px; border-radius: 9999px; object-fit: cover;" %>
+        </div>
+      <% end %>
+      <%= f.file_field :photo %>
+    </div>
+  </div>
+
+  <div class="field-unit field-unit--file">
+    <div class="field-unit__label">
+      <%= f.label :cover_photo, "Cover Photo" %>
+    </div>
+    <div class="field-unit__field">
+      <% if page.resource.persisted? && page.resource.cover_photo.attached? %>
+        <div style="margin-bottom: 8px;">
+          <%= image_tag page.resource.cover_photo, alt: "", style: "height: 60px; width: 120px; border-radius: 4px; object-fit: cover;" %>
+        </div>
+      <% end %>
+      <%= f.file_field :cover_photo %>
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/backend/app/views/admin/book_clubs/show.html.erb
+++ b/backend/app/views/admin/book_clubs/show.html.erb
@@ -1,0 +1,70 @@
+<%#
+# Show BookClub Admin View
+%>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    <%= page.page_title %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) %>
+    <%= link_to(
+      t("administrate.actions.destroy"),
+      [namespace, page.resource],
+      class: "button button--danger",
+      method: :delete,
+      data: { confirm: t("administrate.actions.confirm") }
+    ) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |title, attributes| %>
+      <fieldset class="<%= "fieldset--#{title.parameterize}" if title.present? %>">
+        <% if title.present? %>
+          <legend><h2><%= title %></h2></legend>
+        <% end %>
+
+        <% attributes.each do |attribute| %>
+          <dt class="attribute-label" id="<%= attribute.name %>">
+          <%= t(
+            "helpers.label.#{page.resource_name}.#{attribute.name}",
+            default: attribute.name.titleize,
+          ) %>
+          </dt>
+
+          <dd class="attribute-data attribute-data--<%= attribute.html_class %>"
+              ><%= render_field attribute, page: page %></dd>
+        <% end %>
+      </fieldset>
+    <% end %>
+
+    <fieldset>
+      <legend><h2>Attachments</h2></legend>
+
+      <dt class="attribute-label">Club Avatar Photo</dt>
+      <dd class="attribute-data">
+        <% if page.resource.photo.attached? %>
+          <%= image_tag page.resource.photo, alt: "", style: "width: 64px; height: 64px; border-radius: 9999px; object-fit: cover;" %>
+        <% else %>
+          <span style="color: #666;">No avatar photo attached</span>
+        <% end %>
+      </dd>
+
+      <dt class="attribute-label" style="margin-top: 1rem;">Cover Photo</dt>
+      <dd class="attribute-data">
+        <% if page.resource.cover_photo.attached? %>
+          <%= image_tag page.resource.cover_photo, alt: "", style: "height: 100px; width: 200px; border-radius: 4px; object-fit: cover;" %>
+        <% else %>
+          <span style="color: #666;">No cover photo attached</span>
+        <% end %>
+      </dd>
+    </fieldset>
+  </dl>
+</section>

--- a/backend/app/views/book_clubs/_form.html.erb
+++ b/backend/app/views/book_clubs/_form.html.erb
@@ -21,7 +21,12 @@
   </div>
 
   <div>
-    <%= form.label :cover_photo, class: "block text-sm font-medium text-content mb-1" %>
+    <%= form.label :photo, "Club Avatar Photo", class: "block text-sm font-medium text-content mb-1" %>
+    <%= form.file_field :photo, class: "w-full text-sm text-content-subtle file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-background file:text-primary hover:file:bg-background" %>
+  </div>
+
+  <div>
+    <%= form.label :cover_photo, "Cover Photo", class: "block text-sm font-medium text-content mb-1" %>
     <%= form.file_field :cover_photo, class: "w-full text-sm text-content-subtle file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-background file:text-primary hover:file:bg-background" %>
   </div>
 

--- a/backend/app/views/book_clubs/show.html.erb
+++ b/backend/app/views/book_clubs/show.html.erb
@@ -33,7 +33,16 @@
     <div class="p-8">
       <div class="flex justify-between items-start">
         <div>
-          <h1 class="title title-lg text-content font-bold mb-2"><%= @club.name %></h1>
+          <div class="flex items-center gap-3 mb-2">
+            <% if @club.photo.attached? %>
+              <%= image_tag @club.photo, class: "w-10 h-10 aspect-square rounded-full object-cover ring-2 ring-accent/20 shrink-0" %>
+            <% else %>
+              <div class="w-10 h-10 rounded-full bg-accent/15 text-accent font-bold text-base flex items-center justify-center shrink-0">
+                <%= @club.name_initial %>
+              </div>
+            <% end %>
+            <h1 class="title title-lg text-content font-bold"><%= @club.name %></h1>
+          </div>
           <div class="flex items-center space-x-4 mb-6">
             <span
               class="

--- a/backend/app/views/book_clubs/show.html.erb
+++ b/backend/app/views/book_clubs/show.html.erb
@@ -35,9 +35,9 @@
         <div>
           <div class="flex items-center gap-3 mb-2">
             <% if @club.photo.attached? %>
-              <%= image_tag @club.photo, class: "w-10 h-10 aspect-square rounded-full object-cover ring-2 ring-accent/20 shrink-0" %>
+              <%= image_tag @club.photo, alt: "", class: "w-10 h-10 aspect-square rounded-full object-cover ring-2 ring-accent/20 shrink-0" %>
             <% else %>
-              <div class="w-10 h-10 rounded-full bg-accent/15 text-accent font-bold text-base flex items-center justify-center shrink-0">
+              <div aria-hidden="true" class="w-10 h-10 rounded-full bg-accent/15 text-accent font-bold text-base flex items-center justify-center shrink-0">
                 <%= @club.name_initial %>
               </div>
             <% end %>

--- a/backend/app/views/shared/_book_read_card.html.erb
+++ b/backend/app/views/shared/_book_read_card.html.erb
@@ -27,10 +27,19 @@
   </figure>
 
   <div class="card-body p-4 sm:p-5 min-w-0">
-    <%# Club Name - Theme Accent Upper Label (optional) %>
+    <%# Club Header - Circular Avatar + Accent Name %>
     <% if show_club_name %>
-      <div class="text-xs font-bold uppercase tracking-wider text-accent truncate mb-0.5">
-        <%= club&.name || "Book Club" %>
+      <div class="flex items-center gap-2 mb-1.5 min-w-0">
+        <% if club&.photo&.attached? %>
+          <%= image_tag club.photo, class: "w-7 h-7 aspect-square rounded-full object-cover shrink-0 ring-1 ring-border shadow-xs" %>
+        <% else %>
+          <div class="w-7 h-7 rounded-full bg-accent/15 text-accent font-bold text-xs flex items-center justify-center shrink-0">
+            <%= club&.name_initial || "B" %>
+          </div>
+        <% end %>
+        <span class="text-xs font-bold uppercase tracking-wider text-accent truncate">
+          <%= club&.name || "Book Club" %>
+        </span>
       </div>
     <% end %>
 

--- a/backend/app/views/shared/_book_read_card.html.erb
+++ b/backend/app/views/shared/_book_read_card.html.erb
@@ -31,9 +31,9 @@
     <% if show_club_name %>
       <div class="flex items-center gap-2 mb-1.5 min-w-0">
         <% if club&.photo&.attached? %>
-          <%= image_tag club.photo, class: "w-7 h-7 aspect-square rounded-full object-cover shrink-0 ring-1 ring-border shadow-xs" %>
+          <%= image_tag club.photo, alt: "", class: "w-7 h-7 aspect-square rounded-full object-cover shrink-0 ring-1 ring-border shadow-xs" %>
         <% else %>
-          <div class="w-7 h-7 rounded-full bg-accent/15 text-accent font-bold text-xs flex items-center justify-center shrink-0">
+          <div aria-hidden="true" class="w-7 h-7 rounded-full bg-accent/15 text-accent font-bold text-xs flex items-center justify-center shrink-0">
             <%= club&.name_initial || "B" %>
           </div>
         <% end %>

--- a/backend/app/views/shared/_book_read_skeleton_card.html.erb
+++ b/backend/app/views/shared/_book_read_skeleton_card.html.erb
@@ -4,8 +4,11 @@
   </figure>
 
   <div class="card-body p-4 sm:p-5 min-w-0">
-    <%# Club Name Skeleton (small accent bar) %>
-    <div class="skeleton h-3 w-1/3 mb-0.5"></div>
+    <%# Club Header Skeleton (Circular Avatar + Name bar) %>
+    <div class="flex items-center gap-2 mb-1.5">
+      <div class="skeleton w-7 h-7 rounded-full shrink-0"></div>
+      <div class="skeleton h-3 w-1/3"></div>
+    </div>
 
     <%# Book Title Skeleton (prominent title bar) %>
     <div class="title title-sm font-bold">

--- a/backend/test/models/book_club_test.rb
+++ b/backend/test/models/book_club_test.rb
@@ -14,4 +14,65 @@ class BookClubTest < ActiveSupport::TestCase
     assert_not_nil membership, "Owner should have a membership record"
     assert membership.admin?, "Owner should have the admin role"
   end
+
+  test "rejects photo with invalid content type" do
+    owner = users(:one)
+    club = BookClub.new(name: "Invalid Type Club", owner: owner)
+
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("some file content"),
+      filename: "document.pdf",
+      content_type: "application/pdf"
+    )
+    club.photo.attach(blob)
+
+    assert_not club.valid?
+    assert_includes club.errors[:photo], "must be a JPEG, PNG, WEBP, or GIF image"
+  end
+
+  test "explicitly rejects SVG photo for security reasons" do
+    owner = users(:one)
+    club = BookClub.new(name: "SVG Club", owner: owner)
+
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("<svg></svg>"),
+      filename: "logo.svg",
+      content_type: "image/svg+xml"
+    )
+    club.photo.attach(blob)
+
+    assert_not club.valid?
+    assert_includes club.errors[:photo], "cannot be an SVG file for security reasons"
+  end
+
+  test "rejects photo exceeding maximum byte size" do
+    owner = users(:one)
+    club = BookClub.new(name: "Large Photo Club", owner: owner)
+
+    oversized_data = "x" * (5.megabytes + 100)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(oversized_data),
+      filename: "huge.jpg",
+      content_type: "image/jpeg"
+    )
+    club.photo.attach(blob)
+
+    assert_not club.valid?
+    assert_includes club.errors[:photo], "is too large (maximum size is 5MB)"
+  end
+
+  test "accepts valid JPEG or PNG photo within size limits" do
+    owner = users(:one)
+    club = BookClub.new(name: "Valid Photo Club", owner: owner)
+
+    valid_data = "fake image bytes"
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(valid_data),
+      filename: "avatar.png",
+      content_type: "image/png"
+    )
+    club.photo.attach(blob)
+
+    assert club.valid?
+  end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Book clubs can now have avatar photos uploaded through the club form.
  * Club avatars appear beside names on club pages and book-read cards.
  * Clubs without photos display a fallback initial avatar.
* **Style**
  * Updated club headers and loading placeholders to use a consistent circular avatar and name layout.
  * Clarified the cover photo field label in the book club form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->