### PR TITLE
chore: add_pagination_for_upcoming_book_reads

### DIFF
--- a/backend/app/controllers/home_controller.rb
+++ b/backend/app/controllers/home_controller.rb
@@ -4,8 +4,21 @@ class HomeController < ApplicationController
 
   def upcoming
     @upcoming_book_reads = BookRead.includes(:book, :book_club)
-                                .where("meetup_time >= ?", Time.current).order(meetup_time: :asc)
-    render partial: "home/upcoming_book_reads"
+                                    .where("meetup_time >= ?", Time.current)
+                                    .order(meetup_time: :asc)
+
+    if turbo_frame_request? || request.format.turbo_stream?
+      set_page_and_extract_portion_from @upcoming_book_reads
+      @next_page = @page.next_param
+      @has_next_page = !@page.last?
+    else
+      @next_page = 1
+      @has_next_page = true
+    end
+
+    respond_to do |format|
+      format.html { render partial: "home/upcoming_book_reads" }
+      format.turbo_stream
+    end
   end
 end
-

--- a/backend/app/views/books/_pagination_placeholder.html.erb
+++ b/backend/app/views/books/_pagination_placeholder.html.erb
@@ -7,7 +7,7 @@
       "
     >
       <% 3.times do %>
-        <%= render partial: "books/book_skeleton" %>
+        <%= render partial: "home/upcoming_book_reads_skeleton" %>
       <% end %>
     </div>
   <% end %>

--- a/backend/app/views/home/_pagination_placeholder.html.erb
+++ b/backend/app/views/home/_pagination_placeholder.html.erb
@@ -1,12 +1,13 @@
-<div id="pagination_placeholder">
-    <div
-      class="
-        grid grid-cols-1 min-[450px]:grid-cols-2 md:grid-cols-3 lg:grid-cols-4
-        xl:grid-cols-5 gap-6 mt-6
-      "
-    >
-      <% 3.times do %>
-        <%= render partial: "home/upcoming_book_reads_skeleton" %>
-      <% end %>
-    </div>
+<div id="upcoming_pagination_placeholder">
+  <% if @has_next_page %>
+    <%= turbo_frame_tag "upcoming_book_reads_page_#{@next_page}",
+                        src: upcoming_book_reads_path(page: @next_page, format: :turbo_stream),
+                        loading: :lazy do %>
+      <div class="flex flex-col gap-4 mt-4 w-full">
+        <% 3.times do %>
+          <%= render partial: "home/upcoming_book_reads_skeleton" %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
 </div>

--- a/backend/app/views/home/_pagination_placeholder.html.erb
+++ b/backend/app/views/home/_pagination_placeholder.html.erb
@@ -1,0 +1,12 @@
+<div id="pagination_placeholder">
+    <div
+      class="
+        grid grid-cols-1 min-[450px]:grid-cols-2 md:grid-cols-3 lg:grid-cols-4
+        xl:grid-cols-5 gap-6 mt-6
+      "
+    >
+      <% 3.times do %>
+        <%= render partial: "home/upcoming_book_reads_skeleton" %>
+      <% end %>
+    </div>
+</div>

--- a/backend/app/views/home/_upcoming_book_reads.html.erb
+++ b/backend/app/views/home/_upcoming_book_reads.html.erb
@@ -6,11 +6,12 @@
       </div>
     </div>
 
-    <div class="flex flex-col gap-3">
+    <div id="upcoming_book_reads_list" class="flex flex-col gap-3">
       <% @upcoming_book_reads.each do |book_read| %>
         <%= render "shared/book_read_card_link", book_read: book_read %>
       <% end %>
     </div>
+    <%= render partial: "home/pagination_placeholder" %>
   </div>
 <% end %>
 

--- a/backend/app/views/home/upcoming.turbo_stream.erb
+++ b/backend/app/views/home/upcoming.turbo_stream.erb
@@ -1,0 +1,12 @@
+<%= turbo_stream.append "upcoming_book_reads_list" do %>
+  <% @page.records.each do |book_read| %>
+    <%= render "shared/book_read_card",
+               book: book_read.book,
+               club: book_read.book_club,
+               book_read: book_read %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.replace "upcoming_pagination_placeholder" do %>
+  <%= render partial: "home/pagination_placeholder" %>
+<% end %>


### PR DESCRIPTION
Add pagination for upcoming book reads

Currently we can displaying upcoming book reads on the home page but we don't have pagination if we have many book reads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive loading placeholders while upcoming book entries load.
  * Added progressive pagination for upcoming book reads, allowing additional entries to appear without a full page refresh.
  * Improved loading transitions by replacing placeholders with newly loaded book entries automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->